### PR TITLE
マイグレーションファイル修正

### DIFF
--- a/database/migrations/2023_06_11_100112_create_posts_table.php
+++ b/database/migrations/2023_06_11_100112_create_posts_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */
@@ -14,7 +13,7 @@ return new class extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->id('post_id');
             $table->foreignId('admin_id')->constrained('admins', 'admin_id');
-            $table->foreignId('category_id')->constrained('categories', 'category_id');
+            $table->foreignId('category_id')->nullable()->constrained('categories', 'category_id')->nullOnDelete();
             $table->string('title')->nullable();
             $table->text('content')->nullable();
             $table->string('status')->default('draft');

--- a/database/migrations/2023_06_11_100115_create_comments_table.php
+++ b/database/migrations/2023_06_11_100115_create_comments_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */
@@ -13,7 +12,7 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id('comment_id');
-            $table->foreignId('post_id')->constrained('posts', 'post_id');
+            $table->foreignId('post_id')->constrained('posts', 'post_id')->cascadeOnDelete();
             $table->text('content');
             $table->timestamps();
         });

--- a/database/migrations/2023_06_11_100117_create_post_tag_table.php
+++ b/database/migrations/2023_06_11_100117_create_post_tag_table.php
@@ -4,16 +4,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */
     public function up(): void
     {
         Schema::create('post_tag', function (Blueprint $table) {
-            $table->foreignId('post_id')->constrained('posts', 'post_id');
-            $table->foreignId('tag_id')->constrained('tags', 'tag_id');
+            $table->foreignId('post_id')->constrained('posts', 'post_id')->cascadeOnDelete();
+            $table->foreignId('tag_id')->constrained('tags', 'tag_id')->cascadeOnDelete();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
# 概要
`comments`, `post_tag`テーブルにカスケードを追加
`posts`テーブルにSetNullを追加
## 変更内容
- postsテーブル > category_id（親のcategories削除→該当postsテーブルのcategory_idをnullに （合わせてnullableに）
- commentsテーブル > post_id (親のpost削除→該当commentデータも削除）
- post_tagテーブル > post_id （親のpost削除→該当post_tagデータも削除）
- post_tagテーブル > tag_id (親のtag削除→該当post_tagデータも削除）
※作成直後なので、rollbackして既存マイグレーションを修正
## 関連 Issue/PR
https://github.com/kazu24z/blog-api-laravel/issues/4